### PR TITLE
Fixes

### DIFF
--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -110,7 +110,7 @@ ringbuf_setup(ringbuf_t *rbuf, unsigned nworkers, size_t length)
 		errno = EINVAL;
 		return -1;
 	}
-	memset(rbuf, 0, sizeof(ringbuf_t));
+	memset(rbuf, 0, offsetof(ringbuf_t, workers[nworkers]));
 	rbuf->space = length;
 	rbuf->end = RBUF_OFF_MAX;
 	rbuf->nworkers = nworkers;

--- a/src/ringbuf.h
+++ b/src/ringbuf.h
@@ -14,7 +14,7 @@ typedef struct ringbuf ringbuf_t;
 typedef struct ringbuf_worker ringbuf_worker_t;
 
 int		ringbuf_setup(ringbuf_t *, unsigned, size_t);
-void		ringbuf_get_sizes(unsigned, size_t *, size_t *);
+void		ringbuf_get_sizes(const unsigned, size_t *, size_t *);
 
 ringbuf_worker_t *ringbuf_register(ringbuf_t *, unsigned);
 void		ringbuf_unregister(ringbuf_t *, ringbuf_worker_t *);

--- a/src/t_ringbuf.c
+++ b/src/t_ringbuf.c
@@ -19,7 +19,7 @@ static void
 test_wraparound(void)
 {
 	const size_t n = 1000;
-	ringbuf_t *r = malloc(ringbuf_obj_size);
+	ringbuf_t *r = (ringbuf_t *)malloc(ringbuf_obj_size);
 	ringbuf_worker_t *w;
 	size_t len, woff;
 	ssize_t off;
@@ -62,7 +62,7 @@ test_wraparound(void)
 static void
 test_multi(void)
 {
-	ringbuf_t *r = malloc(ringbuf_obj_size);
+	ringbuf_t *r = (ringbuf_t *)malloc(ringbuf_obj_size);
 	ringbuf_worker_t *w;
 	size_t len, woff;
 	ssize_t off;
@@ -132,7 +132,7 @@ test_multi(void)
 static void
 test_overlap(void)
 {
-	ringbuf_t *r = malloc(ringbuf_obj_size);
+	ringbuf_t *r = (ringbuf_t *)malloc(ringbuf_obj_size);
 	ringbuf_worker_t *w1, *w2;
 	size_t len, woff;
 	ssize_t off;
@@ -205,7 +205,7 @@ test_overlap(void)
 static void
 test_random(void)
 {
-	ringbuf_t *r = malloc(ringbuf_obj_size);
+	ringbuf_t *r = (ringbuf_t *)malloc(ringbuf_obj_size);
 	ringbuf_worker_t *w1, *w2;
 	ssize_t off1 = -1, off2 = -1;
 	unsigned n = 1000 * 1000 * 50;


### PR DESCRIPTION
I found and fixed a few issues when back-porting ringbuf to Visual Studio 2010.
One was a bug in ringbuf_setup() that I'm surprised hadn't been found before -- it made t_ringbuf.c fail.
The second fixed some problems I encountered when building the sources as C++ instead of C.

I'll submit the Visual Studio 2010 port as soon as I've tested it more.
It survived t_ringbuf.c and t_stress.c so far.