### PR TITLE
Used/free stacks for workers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 # This file is in the Public Domain.
 #
 
-CFLAGS=		-std=c11 -O2 -g -W -Wextra -Werror
+CFLAGS=		-std=c11 -g -W -Wextra -Werror
 CFLAGS+=	-D_POSIX_C_SOURCE=200809L
 CFLAGS+=	-D_GNU_SOURCE -D_DEFAULT_SOURCE
 
@@ -23,7 +23,7 @@ endif
 ifeq ($(DEBUG),1)
 CFLAGS+=	-O0 -DDEBUG -fno-omit-frame-pointer
 else
-CFLAGS+=	-DNDEBUG
+CFLAGS+=	-O2 -DNDEBUG
 endif
 
 LIB=		libringbuf

--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -164,6 +164,7 @@ ringbuf_register(ringbuf_t *rbuf, unsigned i)
 		w->next = old_used;
 	} while (!atomic_compare_exchange_weak(&rbuf->used_workers, old_used, w));
 
+	(void)i;
 	return w;
 }
 
@@ -349,7 +350,7 @@ retry:
 			 * Remove this worker from the used-worker stack.
 			 * If it can't be, try again later.
 			 */
-			if (atomic_compare_exchange_weak(&pw, w, w->next)) {
+			if (atomic_compare_exchange_weak(pw, w, w->next)) {
 				/* Push this unused worker on top of the free-worker stack. */
 				do {
 					old_free = rbuf->free_workers;

--- a/src/ringbuf.h
+++ b/src/ringbuf.h
@@ -19,7 +19,7 @@ void		ringbuf_get_sizes(unsigned, size_t *, size_t *);
 ringbuf_worker_t *ringbuf_register(ringbuf_t *, unsigned);
 void		ringbuf_unregister(ringbuf_t *, ringbuf_worker_t *);
 
-ssize_t		ringbuf_acquire(ringbuf_t *, ringbuf_worker_t *, size_t);
+ssize_t		ringbuf_acquire(ringbuf_t *, ringbuf_worker_t **, size_t);
 void		ringbuf_produce(ringbuf_t *, ringbuf_worker_t *);
 size_t		ringbuf_consume(ringbuf_t *, size_t *);
 void		ringbuf_release(ringbuf_t *, size_t);

--- a/src/t_ringbuf.c
+++ b/src/t_ringbuf.c
@@ -26,14 +26,13 @@ test_wraparound(void)
 
 	/* Size n, but only (n - 1) can be produced at a time. */
 	ringbuf_setup(r, MAX_WORKERS, n);
-	w = ringbuf_register(r, 0);
 
 	/* Produce (n / 2 + 1) and then attempt another (n / 2 - 1). */
-	off = ringbuf_acquire(r, w, n / 2 + 1);
+	off = ringbuf_acquire(r, &w, n / 2 + 1);
 	assert(off == 0);
 	ringbuf_produce(r, w);
 
-	off = ringbuf_acquire(r, w, n / 2 - 1);
+	off = ringbuf_acquire(r, &w, n / 2 - 1);
 	assert(off == -1);
 
 	/* Consume (n / 2 + 1) bytes. */
@@ -42,11 +41,11 @@ test_wraparound(void)
 	ringbuf_release(r, len);
 
 	/* All consumed, attempt (n / 2 + 1) now. */
-	off = ringbuf_acquire(r, w, n / 2 + 1);
+	off = ringbuf_acquire(r, &w, n / 2 + 1);
 	assert(off == -1);
 
 	/* However, wraparound can be successful with (n / 2). */
-	off = ringbuf_acquire(r, w, n / 2);
+	off = ringbuf_acquire(r, &w, n / 2);
 	assert(off == 0);
 	ringbuf_produce(r, w);
 
@@ -55,7 +54,6 @@ test_wraparound(void)
 	assert(len == (n / 2) && woff == 0);
 	ringbuf_release(r, len);
 
-	ringbuf_unregister(r, w);
 	free(r);
 }
 
@@ -68,21 +66,20 @@ test_multi(void)
 	ssize_t off;
 
 	ringbuf_setup(r, MAX_WORKERS, 3);
-	w = ringbuf_register(r, 0);
 
 	/*
 	 * Produce 2 bytes.
 	 */
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 0);
 	ringbuf_produce(r, w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 1);
 	ringbuf_produce(r, w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == -1);
 
 	/*
@@ -99,18 +96,18 @@ test_multi(void)
 	 * Produce another 2 with wrap-around.
 	 */
 
-	off = ringbuf_acquire(r, w, 2);
+	off = ringbuf_acquire(r, &w, 2);
 	assert(off == -1);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 2);
 	ringbuf_produce(r, w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 0);
 	ringbuf_produce(r, w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == -1);
 
 	/*
@@ -125,7 +122,6 @@ test_multi(void)
 	assert(len == 1 && woff == 0);
 	ringbuf_release(r, len);
 
-	ringbuf_unregister(r, w);
 	free(r);
 }
 
@@ -138,13 +134,11 @@ test_overlap(void)
 	ssize_t off;
 
 	ringbuf_setup(r, MAX_WORKERS, 10);
-	w1 = ringbuf_register(r, 0);
-	w2 = ringbuf_register(r, 1);
 
 	/*
 	 * Producer 1: acquire 5 bytes.  Consumer should fail.
 	 */
-	off = ringbuf_acquire(r, w1, 5);
+	off = ringbuf_acquire(r, &w1, 5);
 	assert(off == 0);
 
 	len = ringbuf_consume(r, &woff);
@@ -153,7 +147,7 @@ test_overlap(void)
 	/*
 	 * Producer 2: acquire 3 bytes.  Consumer should still fail.
 	 */
-	off = ringbuf_acquire(r, w2, 3);
+	off = ringbuf_acquire(r, &w2, 3);
 	assert(off == 5);
 
 	len = ringbuf_consume(r, &woff);
@@ -174,7 +168,7 @@ test_overlap(void)
 	 * Producer 1: acquire-produce 4 bytes, triggering wrap-around.
 	 * Consumer should still fail.
 	 */
-	off = ringbuf_acquire(r, w1, 4);
+	off = ringbuf_acquire(r, &w1, 4);
 	assert(off == 0);
 
 	len = ringbuf_consume(r, &woff);
@@ -197,8 +191,6 @@ test_overlap(void)
 	assert(len == 4 && woff == 0);
 	ringbuf_release(r, len);
 
-	ringbuf_unregister(r, w1);
-	ringbuf_unregister(r, w2);
 	free(r);
 }
 
@@ -212,8 +204,6 @@ test_random(void)
 	unsigned char buf[500];
 
 	ringbuf_setup(r, MAX_WORKERS, sizeof(buf));
-	w1 = ringbuf_register(r, 0);
-	w2 = ringbuf_register(r, 1);
 
 	while (n--) {
 		size_t len, woff;
@@ -237,7 +227,7 @@ test_random(void)
 			break;
 		case 1:	// producer 1
 			if (off1 == -1) {
-				if ((off1 = ringbuf_acquire(r, w1, len)) >= 0) {
+				if ((off1 = ringbuf_acquire(r, &w1, len)) >= 0) {
 					assert((size_t)off1 < sizeof(buf));
 					buf[off1] = len - 1;
 				}
@@ -249,7 +239,7 @@ test_random(void)
 			break;
 		case 2:	// producer 2
 			if (off2 == -1) {
-				if ((off2 = ringbuf_acquire(r, w2, len)) >= 0) {
+				if ((off2 = ringbuf_acquire(r, &w2, len)) >= 0) {
 					assert((size_t)off2 < sizeof(buf));
 					buf[off2] = len - 1;
 				}
@@ -261,8 +251,6 @@ test_random(void)
 			break;
 		}
 	}
-	ringbuf_unregister(r, w1);
-	ringbuf_unregister(r, w2);
 	free(r);
 }
 

--- a/src/t_ringbuf.c
+++ b/src/t_ringbuf.c
@@ -11,7 +11,7 @@
 
 #include "ringbuf.h"
 
-#define	MAX_WORKERS	2
+#define	MAX_WORKERS	3
 
 static size_t		ringbuf_obj_size;
 

--- a/src/t_stress.c
+++ b/src/t_stress.c
@@ -102,6 +102,7 @@ ringbuf_stress(void *arg)
 {
 	const unsigned id = (uintptr_t)arg;
 	ringbuf_worker_t *w;
+	uint64_t total_recv = 0;
 
 	/*
 	 * There are NCPU threads concurrently generating and producing
@@ -120,6 +121,7 @@ ringbuf_stress(void *arg)
 
 		if (id == 0) {
 			if ((len = ringbuf_consume(ringbuf, &off)) != 0) {
+				total_recv += len;
 				size_t rem = len;
 				assert(off < RBUF_SIZE);
 				while (rem) {
@@ -141,6 +143,8 @@ ringbuf_stress(void *arg)
 		}
 	}
 	pthread_barrier_wait(&barrier);
+	if (id == 0)
+		printf ("Total received: %" PRIu64 "\n", total_recv);
 	pthread_exit(NULL);
 	return NULL;
 }

--- a/src/t_stress.c
+++ b/src/t_stress.c
@@ -103,9 +103,6 @@ ringbuf_stress(void *arg)
 	const unsigned id = (uintptr_t)arg;
 	ringbuf_worker_t *w;
 
-	w = ringbuf_register(ringbuf, id);
-	assert(w != NULL);
-
 	/*
 	 * There are NCPU threads concurrently generating and producing
 	 * random messages and a single consumer thread (ID 0) verifying
@@ -136,7 +133,7 @@ ringbuf_stress(void *arg)
 			continue;
 		}
 		len = generate_message(buf, sizeof(buf) - 1);
-		if ((ret = ringbuf_acquire(ringbuf, w, len)) != -1) {
+		if ((ret = ringbuf_acquire(ringbuf, &w, len)) != -1) {
 			off = (size_t)ret;
 			assert(off < RBUF_SIZE);
 			memcpy(&rbuf[off], buf, len);

--- a/src/utils.h
+++ b/src/utils.h
@@ -93,7 +93,7 @@
 #endif
 #define	SPINLOCK_BACKOFF(count)					\
 do {								\
-	for (int __i = (count); __i != 0; __i--) {		\
+	for (int __i = ((count) + fast_random() % (count)); __i != 0; __i--) {		\
 		SPINLOCK_BACKOFF_HOOK;				\
 	}							\
 	if ((count) < SPINLOCK_BACKOFF_MAX)			\


### PR DESCRIPTION
Now workers are tracked in used/free stacks, and ringbuf_consume() only iterates through in-use workers.

Previously, in-use workers were tracked with a "registered" flag in ringbuf_worker_t, and ringbuf_consume() iterated through all possible workers. This could be inefficient if there were far more potential workers than actual workers.

Presently, ringbuf_worker_t.next is a pointer. If the ABA Problem is considered to be important, it can be changed to an offset into ringbuf_t.workers[] and a counter.

Finally, the "unsigned i" parameter can be removed from ringbuf_register(); I haven't done that yet. I didn't want to change the API yet. But it seems helpful to not force ring-buffer clients to coordinate their index-numbers among each other. (My expected use of ringbuf involves communication between applications using ring-buffers allocated from shared memory, so such coordination is even more difficult.)
