### PR TITLE
Worker-record queue

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 # This file is in the Public Domain.
 #
 
-CFLAGS=		-std=c11 -O2 -g -W -Wextra -Werror
+CFLAGS=		-std=c11 -g -W -Wextra -Werror
 CFLAGS+=	-D_POSIX_C_SOURCE=200809L
 CFLAGS+=	-D_GNU_SOURCE -D_DEFAULT_SOURCE
 
@@ -23,7 +23,7 @@ endif
 ifeq ($(DEBUG),1)
 CFLAGS+=	-O0 -DDEBUG -fno-omit-frame-pointer
 else
-CFLAGS+=	-DNDEBUG
+CFLAGS+=	-O2 -DNDEBUG
 endif
 
 LIB=		libringbuf

--- a/src/ringbuf.h
+++ b/src/ringbuf.h
@@ -13,10 +13,10 @@ __BEGIN_DECLS
 typedef struct ringbuf ringbuf_t;
 typedef struct ringbuf_worker ringbuf_worker_t;
 
-int		ringbuf_setup(ringbuf_t *, unsigned, size_t);
-void		ringbuf_get_sizes(unsigned, size_t *, size_t *);
+int		ringbuf_setup(ringbuf_t *, unsigned, unsigned, size_t);
+void		ringbuf_get_sizes(unsigned, unsigned, size_t *, size_t *);
 
-ringbuf_worker_t *ringbuf_register(ringbuf_t *);
+ringbuf_worker_t *ringbuf_register(ringbuf_t *, unsigned);
 void		ringbuf_unregister(ringbuf_t *, ringbuf_worker_t *);
 
 ssize_t		ringbuf_acquire(ringbuf_t *, ringbuf_worker_t **, size_t);

--- a/src/ringbuf.h
+++ b/src/ringbuf.h
@@ -16,11 +16,11 @@ typedef struct ringbuf_worker ringbuf_worker_t;
 int		ringbuf_setup(ringbuf_t *, unsigned, size_t);
 void		ringbuf_get_sizes(unsigned, size_t *, size_t *);
 
-ringbuf_worker_t *ringbuf_register(ringbuf_t *, unsigned);
+ringbuf_worker_t *ringbuf_register(ringbuf_t *);
 void		ringbuf_unregister(ringbuf_t *, ringbuf_worker_t *);
 
-ssize_t		ringbuf_acquire(ringbuf_t *, ringbuf_worker_t *, size_t);
-void		ringbuf_produce(ringbuf_t *, ringbuf_worker_t *);
+ssize_t		ringbuf_acquire(ringbuf_t *, ringbuf_worker_t **, size_t);
+void		ringbuf_produce(ringbuf_t *, ringbuf_worker_t **);
 size_t		ringbuf_consume(ringbuf_t *, size_t *);
 void		ringbuf_release(ringbuf_t *, size_t);
 

--- a/src/t_ringbuf.c
+++ b/src/t_ringbuf.c
@@ -11,7 +11,7 @@
 
 #include "ringbuf.h"
 
-#define	MAX_WORKERS	2
+#define	MAX_WORKERS	3
 
 static size_t		ringbuf_obj_size;
 
@@ -20,20 +20,19 @@ test_wraparound(void)
 {
 	const size_t n = 1000;
 	ringbuf_t *r = malloc(ringbuf_obj_size);
-	ringbuf_worker_t *w;
+	ringbuf_worker_t *w = NULL;
 	size_t len, woff;
 	ssize_t off;
 
 	/* Size n, but only (n - 1) can be produced at a time. */
 	ringbuf_setup(r, MAX_WORKERS, n);
-	w = ringbuf_register(r, 0);
 
 	/* Produce (n / 2 + 1) and then attempt another (n / 2 - 1). */
-	off = ringbuf_acquire(r, w, n / 2 + 1);
+	off = ringbuf_acquire(r, &w, n / 2 + 1);
 	assert(off == 0);
-	ringbuf_produce(r, w);
+	ringbuf_produce(r, &w);
 
-	off = ringbuf_acquire(r, w, n / 2 - 1);
+	off = ringbuf_acquire(r, &w, n / 2 - 1);
 	assert(off == -1);
 
 	/* Consume (n / 2 + 1) bytes. */
@@ -42,20 +41,19 @@ test_wraparound(void)
 	ringbuf_release(r, len);
 
 	/* All consumed, attempt (n / 2 + 1) now. */
-	off = ringbuf_acquire(r, w, n / 2 + 1);
+	off = ringbuf_acquire(r, &w, n / 2 + 1);
 	assert(off == -1);
 
 	/* However, wraparound can be successful with (n / 2). */
-	off = ringbuf_acquire(r, w, n / 2);
+	off = ringbuf_acquire(r, &w, n / 2);
 	assert(off == 0);
-	ringbuf_produce(r, w);
+	ringbuf_produce(r, &w);
 
 	/* Consume (n / 2) bytes. */
 	len = ringbuf_consume(r, &woff);
 	assert(len == (n / 2) && woff == 0);
 	ringbuf_release(r, len);
 
-	ringbuf_unregister(r, w);
 	free(r);
 }
 
@@ -63,26 +61,25 @@ static void
 test_multi(void)
 {
 	ringbuf_t *r = malloc(ringbuf_obj_size);
-	ringbuf_worker_t *w;
+	ringbuf_worker_t *w = NULL;
 	size_t len, woff;
 	ssize_t off;
 
 	ringbuf_setup(r, MAX_WORKERS, 3);
-	w = ringbuf_register(r, 0);
 
 	/*
 	 * Produce 2 bytes.
 	 */
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 0);
-	ringbuf_produce(r, w);
+	ringbuf_produce(r, &w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 1);
-	ringbuf_produce(r, w);
+	ringbuf_produce(r, &w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == -1);
 
 	/*
@@ -99,18 +96,18 @@ test_multi(void)
 	 * Produce another 2 with wrap-around.
 	 */
 
-	off = ringbuf_acquire(r, w, 2);
+	off = ringbuf_acquire(r, &w, 2);
 	assert(off == -1);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 2);
-	ringbuf_produce(r, w);
+	ringbuf_produce(r, &w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == 0);
-	ringbuf_produce(r, w);
+	ringbuf_produce(r, &w);
 
-	off = ringbuf_acquire(r, w, 1);
+	off = ringbuf_acquire(r, &w, 1);
 	assert(off == -1);
 
 	/*
@@ -125,7 +122,6 @@ test_multi(void)
 	assert(len == 1 && woff == 0);
 	ringbuf_release(r, len);
 
-	ringbuf_unregister(r, w);
 	free(r);
 }
 
@@ -133,18 +129,16 @@ static void
 test_overlap(void)
 {
 	ringbuf_t *r = malloc(ringbuf_obj_size);
-	ringbuf_worker_t *w1, *w2;
+	ringbuf_worker_t *w1 = NULL, *w2 = NULL;
 	size_t len, woff;
 	ssize_t off;
 
 	ringbuf_setup(r, MAX_WORKERS, 10);
-	w1 = ringbuf_register(r, 0);
-	w2 = ringbuf_register(r, 1);
 
 	/*
 	 * Producer 1: acquire 5 bytes.  Consumer should fail.
 	 */
-	off = ringbuf_acquire(r, w1, 5);
+	off = ringbuf_acquire(r, &w1, 5);
 	assert(off == 0);
 
 	len = ringbuf_consume(r, &woff);
@@ -153,7 +147,7 @@ test_overlap(void)
 	/*
 	 * Producer 2: acquire 3 bytes.  Consumer should still fail.
 	 */
-	off = ringbuf_acquire(r, w2, 3);
+	off = ringbuf_acquire(r, &w2, 3);
 	assert(off == 5);
 
 	len = ringbuf_consume(r, &woff);
@@ -162,7 +156,7 @@ test_overlap(void)
 	/*
 	 * Producer 1: commit.  Consumer can get the first range.
 	 */
-	ringbuf_produce(r, w1);
+	ringbuf_produce(r, &w1);
 	len = ringbuf_consume(r, &woff);
 	assert(len == 5 && woff == 0);
 	ringbuf_release(r, len);
@@ -174,13 +168,13 @@ test_overlap(void)
 	 * Producer 1: acquire-produce 4 bytes, triggering wrap-around.
 	 * Consumer should still fail.
 	 */
-	off = ringbuf_acquire(r, w1, 4);
+	off = ringbuf_acquire(r, &w1, 4);
 	assert(off == 0);
 
 	len = ringbuf_consume(r, &woff);
 	assert(len == 0);
 
-	ringbuf_produce(r, w1);
+	ringbuf_produce(r, &w1);
 	len = ringbuf_consume(r, &woff);
 	assert(len == 0);
 
@@ -188,7 +182,7 @@ test_overlap(void)
 	 * Finally, producer 2 commits its 3 bytes.
 	 * Consumer can proceed for both ranges.
 	 */
-	ringbuf_produce(r, w2);
+	ringbuf_produce(r, &w2);
 	len = ringbuf_consume(r, &woff);
 	assert(len == 3 && woff == 5);
 	ringbuf_release(r, len);
@@ -197,8 +191,6 @@ test_overlap(void)
 	assert(len == 4 && woff == 0);
 	ringbuf_release(r, len);
 
-	ringbuf_unregister(r, w1);
-	ringbuf_unregister(r, w2);
 	free(r);
 }
 
@@ -206,14 +198,12 @@ static void
 test_random(void)
 {
 	ringbuf_t *r = malloc(ringbuf_obj_size);
-	ringbuf_worker_t *w1, *w2;
+	ringbuf_worker_t *w1 = NULL, *w2 = NULL;
 	ssize_t off1 = -1, off2 = -1;
 	unsigned n = 1000 * 1000 * 50;
 	unsigned char buf[500];
 
 	ringbuf_setup(r, MAX_WORKERS, sizeof(buf));
-	w1 = ringbuf_register(r, 0);
-	w2 = ringbuf_register(r, 1);
 
 	while (n--) {
 		size_t len, woff;
@@ -237,32 +227,30 @@ test_random(void)
 			break;
 		case 1:	// producer 1
 			if (off1 == -1) {
-				if ((off1 = ringbuf_acquire(r, w1, len)) >= 0) {
+				if ((off1 = ringbuf_acquire(r, &w1, len)) >= 0) {
 					assert((size_t)off1 < sizeof(buf));
 					buf[off1] = len - 1;
 				}
 			} else {
 				buf[off1]++;
-				ringbuf_produce(r, w1);
+				ringbuf_produce(r, &w1);
 				off1 = -1;
 			}
 			break;
 		case 2:	// producer 2
 			if (off2 == -1) {
-				if ((off2 = ringbuf_acquire(r, w2, len)) >= 0) {
+				if ((off2 = ringbuf_acquire(r, &w2, len)) >= 0) {
 					assert((size_t)off2 < sizeof(buf));
 					buf[off2] = len - 1;
 				}
 			} else {
 				buf[off2]++;
-				ringbuf_produce(r, w2);
+				ringbuf_produce(r, &w2);
 				off2 = -1;
 			}
 			break;
 		}
 	}
-	ringbuf_unregister(r, w1);
-	ringbuf_unregister(r, w2);
 	free(r);
 }
 

--- a/src/t_ringbuf.c
+++ b/src/t_ringbuf.c
@@ -11,7 +11,8 @@
 
 #include "ringbuf.h"
 
-#define	MAX_WORKERS	3
+#define	MAX_WORKERS	1
+#define MAX_TEMP_WORKERS 3
 
 static size_t		ringbuf_obj_size;
 
@@ -25,7 +26,7 @@ test_wraparound(void)
 	ssize_t off;
 
 	/* Size n, but only (n - 1) can be produced at a time. */
-	ringbuf_setup(r, MAX_WORKERS, n);
+	ringbuf_setup(r, MAX_WORKERS, MAX_TEMP_WORKERS, n);
 
 	/* Produce (n / 2 + 1) and then attempt another (n / 2 - 1). */
 	off = ringbuf_acquire(r, &w, n / 2 + 1);
@@ -65,7 +66,7 @@ test_multi(void)
 	size_t len, woff;
 	ssize_t off;
 
-	ringbuf_setup(r, MAX_WORKERS, 3);
+	ringbuf_setup(r, MAX_WORKERS, MAX_TEMP_WORKERS, 3);
 
 	/*
 	 * Produce 2 bytes.
@@ -133,7 +134,7 @@ test_overlap(void)
 	size_t len, woff;
 	ssize_t off;
 
-	ringbuf_setup(r, MAX_WORKERS, 10);
+	ringbuf_setup(r, MAX_WORKERS, MAX_TEMP_WORKERS, 10);
 
 	/*
 	 * Producer 1: acquire 5 bytes.  Consumer should fail.
@@ -203,7 +204,7 @@ test_random(void)
 	unsigned n = 1000 * 1000 * 50;
 	unsigned char buf[500];
 
-	ringbuf_setup(r, MAX_WORKERS, sizeof(buf));
+	ringbuf_setup(r, MAX_WORKERS, MAX_TEMP_WORKERS, sizeof(buf));
 
 	while (n--) {
 		size_t len, woff;
@@ -257,7 +258,7 @@ test_random(void)
 int
 main(void)
 {
-	ringbuf_get_sizes(MAX_WORKERS, &ringbuf_obj_size, NULL);
+	ringbuf_get_sizes(MAX_WORKERS, MAX_TEMP_WORKERS, &ringbuf_obj_size, NULL);
 	test_wraparound();
 	test_multi();
 	test_overlap();

--- a/src/t_stress.c
+++ b/src/t_stress.c
@@ -103,7 +103,7 @@ ringbuf_stress(void *arg)
 	const unsigned id = (uintptr_t)arg;
 	ringbuf_worker_t *w = NULL;
 	if (id == 1) {
-		w = ringbuf_register(ringbuf);
+		w = ringbuf_register(ringbuf, 0);
 		assert (w != NULL);
 	}
 	uint64_t total_xmit = 0, total_not_xmit = 0;
@@ -188,11 +188,11 @@ run_test(void *func(void *))
 	/*
 	 * Create a ring buffer.
 	 */
-	ringbuf_get_sizes(nworkers, &ringbuf_obj_size, NULL);
+	ringbuf_get_sizes(1, nworkers, &ringbuf_obj_size, NULL);
 	ringbuf = malloc(ringbuf_obj_size);
 	assert(ringbuf != NULL);
 
-	ringbuf_setup(ringbuf, nworkers, RBUF_SIZE);
+	ringbuf_setup(ringbuf, 1, nworkers, RBUF_SIZE);
 	memset(rbuf, MAGIC_BYTE, sizeof(rbuf));
 
 	/*

--- a/src/t_stress.c
+++ b/src/t_stress.c
@@ -102,8 +102,10 @@ ringbuf_stress(void *arg)
 {
 	const unsigned id = (uintptr_t)arg;
 	ringbuf_worker_t *w = NULL;
-	//ringbuf_worker_t *w = ringbuf_register(ringbuf);
-	//assert (w != NULL);
+	if (id == 1) {
+		w = ringbuf_register(ringbuf);
+		assert (w != NULL);
+	}
 	uint64_t total_recv = 0;
 
 	/*


### PR DESCRIPTION
This accomplishes the same thing that my worker-stack change tried to do, but far more efficiently, plus you can mix permanent and temporary worker-record registration. Also, according to my tests, there seems to be no change in performance.

There's a small bug-fix in the makefile. Without it, the test/stress executables can't be debugged. Trying to view variables in gdb usually results in "&lt;optimized out&gt;". My memory was that later flags provided to gcc override the settings in earlier flags, but that doesn't seem to be true any more. The fix was easy.

ringbuf_worker.registered is now a 64-bit field, but because that struct already had a 64-bit field, there wasn't any change in struct size. Besides, this keeps me from having to implement another compare-and-swap function.

ringbuf.first_free_worker doesn't have to be exact; the intention is to minimize the number of records that have to be searched when registering another worker. This is especially important when using lots of temporary worker-registrations.

I modified t_stress so that one of the worker-records is registered permanently, just to demonstrate that mixing permanent & temporary registration works. I also had it print the total number of bytes received, to make it easy to determine whether new features have performance implications.

The rest of the changes should be easy to understand.
